### PR TITLE
Add testing option flags

### DIFF
--- a/ERC4626.prop.sol
+++ b/ERC4626.prop.sol
@@ -63,17 +63,17 @@ abstract contract ERC4626Prop is Test {
 
     // convertToShares
     // "MUST NOT show any variations depending on the caller."
-    function prop_convertToShares(address caller1, address caller2, uint amount) public {
-        vm.prank(caller1); uint res1 = vault_convertToShares(amount); // "MAY revert due to integer overflow caused by an unreasonably large input."
-        vm.prank(caller2); uint res2 = vault_convertToShares(amount); // "MAY revert due to integer overflow caused by an unreasonably large input."
+    function prop_convertToShares(address caller1, address caller2, uint assets) public {
+        vm.prank(caller1); uint res1 = vault_convertToShares(assets); // "MAY revert due to integer overflow caused by an unreasonably large input."
+        vm.prank(caller2); uint res2 = vault_convertToShares(assets); // "MAY revert due to integer overflow caused by an unreasonably large input."
         assertEq(res1, res2);
     }
 
     // convertToAssets
     // "MUST NOT show any variations depending on the caller."
-    function prop_convertToAssets(address caller1, address caller2, uint amount) public {
-        vm.prank(caller1); uint res1 = vault_convertToAssets(amount); // "MAY revert due to integer overflow caused by an unreasonably large input."
-        vm.prank(caller2); uint res2 = vault_convertToAssets(amount); // "MAY revert due to integer overflow caused by an unreasonably large input."
+    function prop_convertToAssets(address caller1, address caller2, uint shares) public {
+        vm.prank(caller1); uint res1 = vault_convertToAssets(shares); // "MAY revert due to integer overflow caused by an unreasonably large input."
+        vm.prank(caller2); uint res2 = vault_convertToAssets(shares); // "MAY revert due to integer overflow caused by an unreasonably large input."
         assertEq(res1, res2);
     }
 
@@ -169,9 +169,9 @@ abstract contract ERC4626Prop is Test {
     // shares that would be burned in a withdraw call in the same transaction.
     // I.e. withdraw should return the same or fewer shares as previewWithdraw
     // if called in the same transaction."
-    function prop_previewWithdraw(address caller, address receiver, address owner, address other, uint amount) public {
-        vm.prank(other); uint preview = vault_previewWithdraw(amount);
-        vm.prank(caller); uint actual = vault_withdraw(amount, receiver, owner);
+    function prop_previewWithdraw(address caller, address receiver, address owner, address other, uint assets) public {
+        vm.prank(other); uint preview = vault_previewWithdraw(assets);
+        vm.prank(caller); uint actual = vault_withdraw(assets, receiver, owner);
         assertApproxLeAbs(actual, preview, __delta__);
     }
 
@@ -209,9 +209,9 @@ abstract contract ERC4626Prop is Test {
     // would be withdrawn in a redeem call in the same transaction. I.e. redeem
     // should return the same or more assets as previewRedeem if called in the
     // same transaction."
-    function prop_previewRedeem(address caller, address receiver, address owner, address other, uint amount) public {
-        vm.prank(other); uint preview = vault_previewRedeem(amount);
-        vm.prank(caller); uint actual = vault_redeem(amount, receiver, owner);
+    function prop_previewRedeem(address caller, address receiver, address owner, address other, uint shares) public {
+        vm.prank(other); uint preview = vault_previewRedeem(shares);
+        vm.prank(caller); uint actual = vault_redeem(shares, receiver, owner);
         assertApproxGeAbs(actual, preview, __delta__);
     }
 

--- a/ERC4626.prop.sol
+++ b/ERC4626.prop.sol
@@ -41,6 +41,8 @@ abstract contract ERC4626Prop is Test {
     address __underlying__;
     address __vault__;
 
+    bool __vault_may_be_empty__;
+
     //
     // asset
     //
@@ -240,6 +242,7 @@ abstract contract ERC4626Prop is Test {
 
     // redeem(deposit(a)) <= a
     function prop_RT_deposit_redeem(address caller, uint assets) public {
+        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
         vm.prank(caller); uint shares = vault_deposit(assets, caller);
         vm.prank(caller); uint assets2 = vault_redeem(shares, caller, caller);
         assertApproxLeAbs(assets2, assets, __delta__);
@@ -249,6 +252,7 @@ abstract contract ERC4626Prop is Test {
     // s' = withdraw(a)
     // s' >= s
     function prop_RT_deposit_withdraw(address caller, uint assets) public {
+        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
         vm.prank(caller); uint shares1 = vault_deposit(assets, caller);
         vm.prank(caller); uint shares2 = vault_withdraw(assets, caller, caller);
         assertApproxGeAbs(shares2, shares1, __delta__);
@@ -257,6 +261,7 @@ abstract contract ERC4626Prop is Test {
     // deposit(redeem(s)) <= s
     function prop_RT_redeem_deposit(address caller, uint shares) public {
         vm.prank(caller); uint assets = vault_redeem(shares, caller, caller);
+        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
         vm.prank(caller); uint shares2 = vault_deposit(assets, caller);
         assertApproxLeAbs(shares2, shares, __delta__);
     }
@@ -266,12 +271,14 @@ abstract contract ERC4626Prop is Test {
     // a' >= a
     function prop_RT_redeem_mint(address caller, uint shares) public {
         vm.prank(caller); uint assets1 = vault_redeem(shares, caller, caller);
+        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
         vm.prank(caller); uint assets2 = vault_mint(shares, caller);
         assertApproxGeAbs(assets2, assets1, __delta__);
     }
 
     // withdraw(mint(s)) >= s
     function prop_RT_mint_withdraw(address caller, uint shares) public {
+        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
         vm.prank(caller); uint assets = vault_mint(shares, caller);
         vm.prank(caller); uint shares2 = vault_withdraw(assets, caller, caller);
         assertApproxGeAbs(shares2, shares, __delta__);
@@ -281,6 +288,7 @@ abstract contract ERC4626Prop is Test {
     // a' = redeem(s)
     // a' <= a
     function prop_RT_mint_redeem(address caller, uint shares) public {
+        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
         vm.prank(caller); uint assets1 = vault_mint(shares, caller);
         vm.prank(caller); uint assets2 = vault_redeem(shares, caller, caller);
         assertApproxLeAbs(assets2, assets1, __delta__);
@@ -289,6 +297,7 @@ abstract contract ERC4626Prop is Test {
     // mint(withdraw(a)) >= a
     function prop_RT_withdraw_mint(address caller, uint assets) public {
         vm.prank(caller); uint shares = vault_withdraw(assets, caller, caller);
+        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
         vm.prank(caller); uint assets2 = vault_mint(shares, caller);
         assertApproxGeAbs(assets2, assets, __delta__);
     }
@@ -298,6 +307,7 @@ abstract contract ERC4626Prop is Test {
     // s' <= s
     function prop_RT_withdraw_deposit(address caller, uint assets) public {
         vm.prank(caller); uint shares1 = vault_withdraw(assets, caller, caller);
+        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
         vm.prank(caller); uint shares2 = vault_deposit(assets, caller);
         assertApproxLeAbs(shares2, shares1, __delta__);
     }

--- a/ERC4626.prop.sol
+++ b/ERC4626.prop.sol
@@ -42,6 +42,7 @@ abstract contract ERC4626Prop is Test {
     address __vault__;
 
     bool __vault_may_be_empty__;
+    bool __unlimited_amount__;
 
     //
     // asset

--- a/ERC4626.prop.sol
+++ b/ERC4626.prop.sol
@@ -3,6 +3,8 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import "forge-std/Test.sol";
 
+// TODO: use interface provided by forge-std v1.0.0 or later
+// import {IERC20} from "forge-std/interfaces/IERC20.sol";
 interface IERC20 {
     event Transfer(address indexed from, address indexed to, uint value);
     event Approval(address indexed owner, address indexed spender, uint value);
@@ -14,6 +16,8 @@ interface IERC20 {
     function transferFrom(address from, address to, uint amount) external returns (bool);
 }
 
+// TODO: use interface provided by forge-std v1.0.0 or later
+// import {IERC4626} from "forge-std/interfaces/IERC4626.sol";
 interface IERC4626 is IERC20 {
     event Deposit(address indexed caller, address indexed owner, uint assets, uint shares);
     event Withdraw(address indexed caller, address indexed receiver, address indexed owner, uint assets, uint shares);
@@ -36,13 +40,13 @@ interface IERC4626 is IERC20 {
 }
 
 abstract contract ERC4626Prop is Test {
-    uint __delta__;
+    uint internal _delta_;
 
-    address __underlying__;
-    address __vault__;
+    address internal _underlying_;
+    address internal _vault_;
 
-    bool __vault_may_be_empty__;
-    bool __unlimited_amount__;
+    bool internal _vaultMayBeEmpty;
+    bool internal _unlimitedAmount;
 
     //
     // asset
@@ -51,13 +55,13 @@ abstract contract ERC4626Prop is Test {
     // asset
     // "MUST NOT revert."
     function prop_asset(address caller) public {
-        vm.prank(caller); IERC4626(__vault__).asset();
+        vm.prank(caller); IERC4626(_vault_).asset();
     }
 
     // totalAssets
     // "MUST NOT revert."
     function prop_totalAssets(address caller) public {
-        vm.prank(caller); IERC4626(__vault__).totalAssets();
+        vm.prank(caller); IERC4626(_vault_).totalAssets();
     }
 
     //
@@ -87,7 +91,7 @@ abstract contract ERC4626Prop is Test {
     // maxDeposit
     // "MUST NOT revert."
     function prop_maxDeposit(address caller, address receiver) public {
-        vm.prank(caller); IERC4626(__vault__).maxDeposit(receiver);
+        vm.prank(caller); IERC4626(_vault_).maxDeposit(receiver);
     }
 
     // previewDeposit
@@ -98,24 +102,24 @@ abstract contract ERC4626Prop is Test {
     function prop_previewDeposit(address caller, address receiver, address other, uint assets) public {
         vm.prank(other); uint sharesPreview = vault_previewDeposit(assets); // "MAY revert due to other conditions that would also cause deposit to revert."
         vm.prank(caller); uint sharesActual = vault_deposit(assets, receiver);
-        assertApproxGeAbs(sharesActual, sharesPreview, __delta__);
+        assertApproxGeAbs(sharesActual, sharesPreview, _delta_);
     }
 
     // deposit
     function prop_deposit(address caller, address receiver, uint assets) public {
-        uint oldCallerAsset = IERC20(__underlying__).balanceOf(caller);
-        uint oldReceiverShare = IERC20(__vault__).balanceOf(receiver);
-        uint oldAllowance = IERC20(__underlying__).allowance(caller, __vault__);
+        uint oldCallerAsset = IERC20(_underlying_).balanceOf(caller);
+        uint oldReceiverShare = IERC20(_vault_).balanceOf(receiver);
+        uint oldAllowance = IERC20(_underlying_).allowance(caller, _vault_);
 
         vm.prank(caller); uint shares = vault_deposit(assets, receiver);
 
-        uint newCallerAsset = IERC20(__underlying__).balanceOf(caller);
-        uint newReceiverShare = IERC20(__vault__).balanceOf(receiver);
-        uint newAllowance = IERC20(__underlying__).allowance(caller, __vault__);
+        uint newCallerAsset = IERC20(_underlying_).balanceOf(caller);
+        uint newReceiverShare = IERC20(_vault_).balanceOf(receiver);
+        uint newAllowance = IERC20(_underlying_).allowance(caller, _vault_);
 
-        assertApproxEqAbs(newCallerAsset, oldCallerAsset - assets, __delta__, "asset"); // NOTE: this may fail if the caller is a contract in which the asset is stored
-        assertApproxEqAbs(newReceiverShare, oldReceiverShare + shares, __delta__, "share");
-        if (oldAllowance != type(uint).max) assertApproxEqAbs(newAllowance, oldAllowance - assets, __delta__, "allowance");
+        assertApproxEqAbs(newCallerAsset, oldCallerAsset - assets, _delta_, "asset"); // NOTE: this may fail if the caller is a contract in which the asset is stored
+        assertApproxEqAbs(newReceiverShare, oldReceiverShare + shares, _delta_, "share");
+        if (oldAllowance != type(uint).max) assertApproxEqAbs(newAllowance, oldAllowance - assets, _delta_, "allowance");
     }
 
     //
@@ -125,7 +129,7 @@ abstract contract ERC4626Prop is Test {
     // maxMint
     // "MUST NOT revert."
     function prop_maxMint(address caller, address receiver) public {
-        vm.prank(caller); IERC4626(__vault__).maxMint(receiver);
+        vm.prank(caller); IERC4626(_vault_).maxMint(receiver);
     }
 
     // previewMint
@@ -136,24 +140,24 @@ abstract contract ERC4626Prop is Test {
     function prop_previewMint(address caller, address receiver, address other, uint shares) public {
         vm.prank(other); uint assetsPreview = vault_previewMint(shares);
         vm.prank(caller); uint assetsActual = vault_mint(shares, receiver);
-        assertApproxLeAbs(assetsActual, assetsPreview, __delta__);
+        assertApproxLeAbs(assetsActual, assetsPreview, _delta_);
     }
 
     // mint
     function prop_mint(address caller, address receiver, uint shares) public {
-        uint oldCallerAsset = IERC20(__underlying__).balanceOf(caller);
-        uint oldReceiverShare = IERC20(__vault__).balanceOf(receiver);
-        uint oldAllowance = IERC20(__underlying__).allowance(caller, __vault__);
+        uint oldCallerAsset = IERC20(_underlying_).balanceOf(caller);
+        uint oldReceiverShare = IERC20(_vault_).balanceOf(receiver);
+        uint oldAllowance = IERC20(_underlying_).allowance(caller, _vault_);
 
         vm.prank(caller); uint assets = vault_mint(shares, receiver);
 
-        uint newCallerAsset = IERC20(__underlying__).balanceOf(caller);
-        uint newReceiverShare = IERC20(__vault__).balanceOf(receiver);
-        uint newAllowance = IERC20(__underlying__).allowance(caller, __vault__);
+        uint newCallerAsset = IERC20(_underlying_).balanceOf(caller);
+        uint newReceiverShare = IERC20(_vault_).balanceOf(receiver);
+        uint newAllowance = IERC20(_underlying_).allowance(caller, _vault_);
 
-        assertApproxEqAbs(newCallerAsset, oldCallerAsset - assets, __delta__, "asset"); // NOTE: this may fail if the caller is a contract in which the asset is stored
-        assertApproxEqAbs(newReceiverShare, oldReceiverShare + shares, __delta__, "share");
-        if (oldAllowance != type(uint).max) assertApproxEqAbs(newAllowance, oldAllowance - assets, __delta__, "allowance");
+        assertApproxEqAbs(newCallerAsset, oldCallerAsset - assets, _delta_, "asset"); // NOTE: this may fail if the caller is a contract in which the asset is stored
+        assertApproxEqAbs(newReceiverShare, oldReceiverShare + shares, _delta_, "share");
+        if (oldAllowance != type(uint).max) assertApproxEqAbs(newAllowance, oldAllowance - assets, _delta_, "allowance");
     }
 
     //
@@ -164,7 +168,7 @@ abstract contract ERC4626Prop is Test {
     // "MUST NOT revert."
     // NOTE: some implementations failed due to arithmetic overflow
     function prop_maxWithdraw(address caller, address owner) public {
-        vm.prank(caller); IERC4626(__vault__).maxWithdraw(owner);
+        vm.prank(caller); IERC4626(_vault_).maxWithdraw(owner);
     }
 
     // previewWithdraw
@@ -175,24 +179,24 @@ abstract contract ERC4626Prop is Test {
     function prop_previewWithdraw(address caller, address receiver, address owner, address other, uint assets) public {
         vm.prank(other); uint preview = vault_previewWithdraw(assets);
         vm.prank(caller); uint actual = vault_withdraw(assets, receiver, owner);
-        assertApproxLeAbs(actual, preview, __delta__);
+        assertApproxLeAbs(actual, preview, _delta_);
     }
 
     // withdraw
     function prop_withdraw(address caller, address receiver, address owner, uint assets) public {
-        uint oldReceiverAsset = IERC20(__underlying__).balanceOf(receiver);
-        uint oldOwnerShare = IERC20(__vault__).balanceOf(owner);
-        uint oldAllowance = IERC20(__vault__).allowance(owner, caller);
+        uint oldReceiverAsset = IERC20(_underlying_).balanceOf(receiver);
+        uint oldOwnerShare = IERC20(_vault_).balanceOf(owner);
+        uint oldAllowance = IERC20(_vault_).allowance(owner, caller);
 
         vm.prank(caller); uint shares = vault_withdraw(assets, receiver, owner);
 
-        uint newReceiverAsset = IERC20(__underlying__).balanceOf(receiver);
-        uint newOwnerShare = IERC20(__vault__).balanceOf(owner);
-        uint newAllowance = IERC20(__vault__).allowance(owner, caller);
+        uint newReceiverAsset = IERC20(_underlying_).balanceOf(receiver);
+        uint newOwnerShare = IERC20(_vault_).balanceOf(owner);
+        uint newAllowance = IERC20(_vault_).allowance(owner, caller);
 
-        assertApproxEqAbs(newOwnerShare, oldOwnerShare - shares, __delta__, "share");
-        assertApproxEqAbs(newReceiverAsset, oldReceiverAsset + assets, __delta__, "asset"); // NOTE: this may fail if the receiver is a contract in which the asset is stored
-        if (caller != owner && oldAllowance != type(uint).max) assertApproxEqAbs(newAllowance, oldAllowance - shares, __delta__, "allowance");
+        assertApproxEqAbs(newOwnerShare, oldOwnerShare - shares, _delta_, "share");
+        assertApproxEqAbs(newReceiverAsset, oldReceiverAsset + assets, _delta_, "asset"); // NOTE: this may fail if the receiver is a contract in which the asset is stored
+        if (caller != owner && oldAllowance != type(uint).max) assertApproxEqAbs(newAllowance, oldAllowance - shares, _delta_, "allowance");
 
         assertTrue(caller == owner || oldAllowance != 0 || (shares == 0 && assets == 0), "access control");
     }
@@ -204,7 +208,7 @@ abstract contract ERC4626Prop is Test {
     // maxRedeem
     // "MUST NOT revert."
     function prop_maxRedeem(address caller, address owner) public {
-        vm.prank(caller); IERC4626(__vault__).maxRedeem(owner);
+        vm.prank(caller); IERC4626(_vault_).maxRedeem(owner);
     }
 
     // previewRedeem
@@ -215,24 +219,24 @@ abstract contract ERC4626Prop is Test {
     function prop_previewRedeem(address caller, address receiver, address owner, address other, uint shares) public {
         vm.prank(other); uint preview = vault_previewRedeem(shares);
         vm.prank(caller); uint actual = vault_redeem(shares, receiver, owner);
-        assertApproxGeAbs(actual, preview, __delta__);
+        assertApproxGeAbs(actual, preview, _delta_);
     }
 
     // redeem
     function prop_redeem(address caller, address receiver, address owner, uint shares) public {
-        uint oldReceiverAsset = IERC20(__underlying__).balanceOf(receiver);
-        uint oldOwnerShare = IERC20(__vault__).balanceOf(owner);
-        uint oldAllowance = IERC20(__vault__).allowance(owner, caller);
+        uint oldReceiverAsset = IERC20(_underlying_).balanceOf(receiver);
+        uint oldOwnerShare = IERC20(_vault_).balanceOf(owner);
+        uint oldAllowance = IERC20(_vault_).allowance(owner, caller);
 
         vm.prank(caller); uint assets = vault_redeem(shares, receiver, owner);
 
-        uint newReceiverAsset = IERC20(__underlying__).balanceOf(receiver);
-        uint newOwnerShare = IERC20(__vault__).balanceOf(owner);
-        uint newAllowance = IERC20(__vault__).allowance(owner, caller);
+        uint newReceiverAsset = IERC20(_underlying_).balanceOf(receiver);
+        uint newOwnerShare = IERC20(_vault_).balanceOf(owner);
+        uint newAllowance = IERC20(_vault_).allowance(owner, caller);
 
-        assertApproxEqAbs(newOwnerShare, oldOwnerShare - shares, __delta__, "share");
-        assertApproxEqAbs(newReceiverAsset, oldReceiverAsset + assets, __delta__, "asset"); // NOTE: this may fail if the receiver is a contract in which the asset is stored
-        if (caller != owner && oldAllowance != type(uint).max) assertApproxEqAbs(newAllowance, oldAllowance - shares, __delta__, "allowance");
+        assertApproxEqAbs(newOwnerShare, oldOwnerShare - shares, _delta_, "share");
+        assertApproxEqAbs(newReceiverAsset, oldReceiverAsset + assets, _delta_, "asset"); // NOTE: this may fail if the receiver is a contract in which the asset is stored
+        if (caller != owner && oldAllowance != type(uint).max) assertApproxEqAbs(newAllowance, oldAllowance - shares, _delta_, "allowance");
 
         assertTrue(caller == owner || oldAllowance != 0 || (shares == 0 && assets == 0), "access control");
     }
@@ -243,28 +247,28 @@ abstract contract ERC4626Prop is Test {
 
     // redeem(deposit(a)) <= a
     function prop_RT_deposit_redeem(address caller, uint assets) public {
-        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
+        if (!_vaultMayBeEmpty) vm.assume(IERC20(_vault_).totalSupply() > 0);
         vm.prank(caller); uint shares = vault_deposit(assets, caller);
         vm.prank(caller); uint assets2 = vault_redeem(shares, caller, caller);
-        assertApproxLeAbs(assets2, assets, __delta__);
+        assertApproxLeAbs(assets2, assets, _delta_);
     }
 
     // s = deposit(a)
     // s' = withdraw(a)
     // s' >= s
     function prop_RT_deposit_withdraw(address caller, uint assets) public {
-        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
+        if (!_vaultMayBeEmpty) vm.assume(IERC20(_vault_).totalSupply() > 0);
         vm.prank(caller); uint shares1 = vault_deposit(assets, caller);
         vm.prank(caller); uint shares2 = vault_withdraw(assets, caller, caller);
-        assertApproxGeAbs(shares2, shares1, __delta__);
+        assertApproxGeAbs(shares2, shares1, _delta_);
     }
 
     // deposit(redeem(s)) <= s
     function prop_RT_redeem_deposit(address caller, uint shares) public {
         vm.prank(caller); uint assets = vault_redeem(shares, caller, caller);
-        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
+        if (!_vaultMayBeEmpty) vm.assume(IERC20(_vault_).totalSupply() > 0);
         vm.prank(caller); uint shares2 = vault_deposit(assets, caller);
-        assertApproxLeAbs(shares2, shares, __delta__);
+        assertApproxLeAbs(shares2, shares, _delta_);
     }
 
     // a = redeem(s)
@@ -272,35 +276,35 @@ abstract contract ERC4626Prop is Test {
     // a' >= a
     function prop_RT_redeem_mint(address caller, uint shares) public {
         vm.prank(caller); uint assets1 = vault_redeem(shares, caller, caller);
-        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
+        if (!_vaultMayBeEmpty) vm.assume(IERC20(_vault_).totalSupply() > 0);
         vm.prank(caller); uint assets2 = vault_mint(shares, caller);
-        assertApproxGeAbs(assets2, assets1, __delta__);
+        assertApproxGeAbs(assets2, assets1, _delta_);
     }
 
     // withdraw(mint(s)) >= s
     function prop_RT_mint_withdraw(address caller, uint shares) public {
-        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
+        if (!_vaultMayBeEmpty) vm.assume(IERC20(_vault_).totalSupply() > 0);
         vm.prank(caller); uint assets = vault_mint(shares, caller);
         vm.prank(caller); uint shares2 = vault_withdraw(assets, caller, caller);
-        assertApproxGeAbs(shares2, shares, __delta__);
+        assertApproxGeAbs(shares2, shares, _delta_);
     }
 
     // a = mint(s)
     // a' = redeem(s)
     // a' <= a
     function prop_RT_mint_redeem(address caller, uint shares) public {
-        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
+        if (!_vaultMayBeEmpty) vm.assume(IERC20(_vault_).totalSupply() > 0);
         vm.prank(caller); uint assets1 = vault_mint(shares, caller);
         vm.prank(caller); uint assets2 = vault_redeem(shares, caller, caller);
-        assertApproxLeAbs(assets2, assets1, __delta__);
+        assertApproxLeAbs(assets2, assets1, _delta_);
     }
 
     // mint(withdraw(a)) >= a
     function prop_RT_withdraw_mint(address caller, uint assets) public {
         vm.prank(caller); uint shares = vault_withdraw(assets, caller, caller);
-        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
+        if (!_vaultMayBeEmpty) vm.assume(IERC20(_vault_).totalSupply() > 0);
         vm.prank(caller); uint assets2 = vault_mint(shares, caller);
-        assertApproxGeAbs(assets2, assets, __delta__);
+        assertApproxGeAbs(assets2, assets, _delta_);
     }
 
     // s = withdraw(a)
@@ -308,9 +312,9 @@ abstract contract ERC4626Prop is Test {
     // s' <= s
     function prop_RT_withdraw_deposit(address caller, uint assets) public {
         vm.prank(caller); uint shares1 = vault_withdraw(assets, caller, caller);
-        if (!__vault_may_be_empty__) vm.assume(IERC20(__vault__).totalSupply() > 0);
+        if (!_vaultMayBeEmpty) vm.assume(IERC20(_vault_).totalSupply() > 0);
         vm.prank(caller); uint shares2 = vault_deposit(assets, caller);
-        assertApproxLeAbs(shares2, shares1, __delta__);
+        assertApproxLeAbs(shares2, shares1, _delta_);
     }
 
     //
@@ -364,7 +368,7 @@ abstract contract ERC4626Prop is Test {
     }
 
     function _call_vault(bytes memory data) internal returns (uint) {
-        (bool success, bytes memory retdata) = __vault__.call(data);
+        (bool success, bytes memory retdata) = _vault_.call(data);
         if (success) return abi.decode(retdata, (uint));
         vm.assume(false); // if reverted, discard the current fuzz inputs, and let the fuzzer to start a new fuzz run
         return 0; // silence warning

--- a/ERC4626.prop.sol
+++ b/ERC4626.prop.sol
@@ -323,6 +323,19 @@ abstract contract ERC4626Prop is Test {
         return _call_vault(abi.encodeWithSelector(IERC4626.convertToAssets.selector, shares));
     }
 
+    function vault_maxDeposit(address receiver) internal returns (uint) {
+        return _call_vault(abi.encodeWithSelector(IERC4626.maxDeposit.selector, receiver));
+    }
+    function vault_maxMint(address receiver) internal returns (uint) {
+        return _call_vault(abi.encodeWithSelector(IERC4626.maxMint.selector, receiver));
+    }
+    function vault_maxWithdraw(address owner) internal returns (uint) {
+        return _call_vault(abi.encodeWithSelector(IERC4626.maxWithdraw.selector, owner));
+    }
+    function vault_maxRedeem(address owner) internal returns (uint) {
+        return _call_vault(abi.encodeWithSelector(IERC4626.maxRedeem.selector, owner));
+    }
+
     function vault_previewDeposit(uint assets) internal returns (uint) {
         return _call_vault(abi.encodeWithSelector(IERC4626.previewDeposit.selector, assets));
     }

--- a/ERC4626.test.sol
+++ b/ERC4626.test.sol
@@ -78,18 +78,18 @@ abstract contract ERC4626Test is ERC4626Prop {
     // convert
     //
 
-    function test_convertToShares(Init memory init, uint amount) public virtual {
+    function test_convertToShares(Init memory init, uint assets) public virtual {
         setupVault(init);
         address caller1 = init.user[0];
         address caller2 = init.user[1];
-        prop_convertToShares(caller1, caller2, amount);
+        prop_convertToShares(caller1, caller2, assets);
     }
 
-    function test_convertToAssets(Init memory init, uint amount) public virtual {
+    function test_convertToAssets(Init memory init, uint shares) public virtual {
         setupVault(init);
         address caller1 = init.user[0];
         address caller2 = init.user[1];
-        prop_convertToAssets(caller1, caller2, amount);
+        prop_convertToAssets(caller1, caller2, shares);
     }
 
     //
@@ -159,14 +159,14 @@ abstract contract ERC4626Test is ERC4626Prop {
         prop_maxWithdraw(caller, owner);
     }
 
-    function test_previewWithdraw(Init memory init, uint amount) public virtual {
+    function test_previewWithdraw(Init memory init, uint assets) public virtual {
         setupVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
         address owner    = init.user[2];
         address other    = init.user[3];
         _approve(__vault__, owner, caller, type(uint).max);
-        prop_previewWithdraw(caller, receiver, owner, other, amount);
+        prop_previewWithdraw(caller, receiver, owner, other, assets);
     }
 
     function test_withdraw(Init memory init, uint assets, uint allowance) public virtual {
@@ -201,14 +201,14 @@ abstract contract ERC4626Test is ERC4626Prop {
         prop_maxRedeem(caller, owner);
     }
 
-    function test_previewRedeem(Init memory init, uint amount) public virtual {
+    function test_previewRedeem(Init memory init, uint shares) public virtual {
         setupVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
         address owner    = init.user[2];
         address other    = init.user[3];
         _approve(__vault__, owner, caller, type(uint).max);
-        prop_previewRedeem(caller, receiver, owner, other, amount);
+        prop_previewRedeem(caller, receiver, owner, other, shares);
     }
 
     function test_redeem(Init memory init, uint shares, uint allowance) public virtual {

--- a/ERC4626.test.sol
+++ b/ERC4626.test.sol
@@ -328,18 +328,22 @@ abstract contract ERC4626Test is ERC4626Prop {
     }
 
     function _max_deposit(address from) internal virtual returns (uint) {
+        if (__unlimited_amount__) return type(uint).max;
         return IERC20(__underlying__).balanceOf(from);
     }
 
     function _max_mint(address from) internal virtual returns (uint) {
+        if (__unlimited_amount__) return type(uint).max;
         return vault_convertToShares(IERC20(__underlying__).balanceOf(from));
     }
 
     function _max_withdraw(address from) internal virtual returns (uint) {
+        if (__unlimited_amount__) return type(uint).max;
         return vault_convertToAssets(IERC20(__vault__).balanceOf(from)); // may be different from maxWithdraw(from)
     }
 
     function _max_redeem(address from) internal virtual returns (uint) {
+        if (__unlimited_amount__) return type(uint).max;
         return IERC20(__vault__).balanceOf(from); // may be different from maxRedeem(from)
     }
 }

--- a/ERC4626.test.sol
+++ b/ERC4626.test.sol
@@ -108,6 +108,7 @@ abstract contract ERC4626Test is ERC4626Prop {
         address caller   = init.user[0];
         address receiver = init.user[1];
         address other    = init.user[2];
+        assets = bound(assets, 0, _max_deposit(caller));
         _approve(__underlying__, caller, __vault__, type(uint).max);
         prop_previewDeposit(caller, receiver, other, assets);
     }
@@ -116,6 +117,7 @@ abstract contract ERC4626Test is ERC4626Prop {
         setupVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
+        assets = bound(assets, 0, _max_deposit(caller));
         _approve(__underlying__, caller, __vault__, allowance);
         prop_deposit(caller, receiver, assets);
     }
@@ -136,6 +138,7 @@ abstract contract ERC4626Test is ERC4626Prop {
         address caller   = init.user[0];
         address receiver = init.user[1];
         address other    = init.user[2];
+        shares = bound(shares, 0, _max_mint(caller));
         _approve(__underlying__, caller, __vault__, type(uint).max);
         prop_previewMint(caller, receiver, other, shares);
     }
@@ -144,6 +147,7 @@ abstract contract ERC4626Test is ERC4626Prop {
         setupVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
+        shares = bound(shares, 0, _max_mint(caller));
         _approve(__underlying__, caller, __vault__, allowance);
         prop_mint(caller, receiver, shares);
     }
@@ -165,6 +169,7 @@ abstract contract ERC4626Test is ERC4626Prop {
         address receiver = init.user[1];
         address owner    = init.user[2];
         address other    = init.user[3];
+        assets = bound(assets, 0, _max_withdraw(owner));
         _approve(__vault__, owner, caller, type(uint).max);
         prop_previewWithdraw(caller, receiver, owner, other, assets);
     }
@@ -174,6 +179,7 @@ abstract contract ERC4626Test is ERC4626Prop {
         address caller   = init.user[0];
         address receiver = init.user[1];
         address owner    = init.user[2];
+        assets = bound(assets, 0, _max_withdraw(owner));
         _approve(__vault__, owner, caller, allowance);
         prop_withdraw(caller, receiver, owner, assets);
     }
@@ -183,6 +189,7 @@ abstract contract ERC4626Test is ERC4626Prop {
         address caller   = init.user[0];
         address receiver = init.user[1];
         address owner    = init.user[2];
+        assets = bound(assets, 0, _max_withdraw(owner));
         vm.assume(caller != owner);
         vm.assume(assets > 0);
         _approve(__vault__, owner, caller, 0);
@@ -207,6 +214,7 @@ abstract contract ERC4626Test is ERC4626Prop {
         address receiver = init.user[1];
         address owner    = init.user[2];
         address other    = init.user[3];
+        shares = bound(shares, 0, _max_redeem(owner));
         _approve(__vault__, owner, caller, type(uint).max);
         prop_previewRedeem(caller, receiver, owner, other, shares);
     }
@@ -216,6 +224,7 @@ abstract contract ERC4626Test is ERC4626Prop {
         address caller   = init.user[0];
         address receiver = init.user[1];
         address owner    = init.user[2];
+        shares = bound(shares, 0, _max_redeem(owner));
         _approve(__vault__, owner, caller, allowance);
         prop_redeem(caller, receiver, owner, shares);
     }
@@ -225,6 +234,7 @@ abstract contract ERC4626Test is ERC4626Prop {
         address caller   = init.user[0];
         address receiver = init.user[1];
         address owner    = init.user[2];
+        shares = bound(shares, 0, _max_redeem(owner));
         vm.assume(caller != owner);
         vm.assume(shares > 0);
         _approve(__vault__, owner, caller, 0);
@@ -238,6 +248,7 @@ abstract contract ERC4626Test is ERC4626Prop {
     function test_RT_deposit_redeem(Init memory init, uint assets) public virtual {
         setupVault(init);
         address caller = init.user[0];
+        assets = bound(assets, 0, _max_deposit(caller));
         _approve(__underlying__, caller, __vault__, type(uint).max);
         prop_RT_deposit_redeem(caller, assets);
     }
@@ -245,6 +256,7 @@ abstract contract ERC4626Test is ERC4626Prop {
     function test_RT_deposit_withdraw(Init memory init, uint assets) public virtual {
         setupVault(init);
         address caller = init.user[0];
+        assets = bound(assets, 0, _max_deposit(caller));
         _approve(__underlying__, caller, __vault__, type(uint).max);
         prop_RT_deposit_withdraw(caller, assets);
     }
@@ -252,6 +264,7 @@ abstract contract ERC4626Test is ERC4626Prop {
     function test_RT_redeem_deposit(Init memory init, uint shares) public virtual {
         setupVault(init);
         address caller = init.user[0];
+        shares = bound(shares, 0, _max_redeem(caller));
         _approve(__underlying__, caller, __vault__, type(uint).max);
         prop_RT_redeem_deposit(caller, shares);
     }
@@ -259,6 +272,7 @@ abstract contract ERC4626Test is ERC4626Prop {
     function test_RT_redeem_mint(Init memory init, uint shares) public virtual {
         setupVault(init);
         address caller = init.user[0];
+        shares = bound(shares, 0, _max_redeem(caller));
         _approve(__underlying__, caller, __vault__, type(uint).max);
         prop_RT_redeem_mint(caller, shares);
     }
@@ -266,6 +280,7 @@ abstract contract ERC4626Test is ERC4626Prop {
     function test_RT_mint_withdraw(Init memory init, uint shares) public virtual {
         setupVault(init);
         address caller = init.user[0];
+        shares = bound(shares, 0, _max_mint(caller));
         _approve(__underlying__, caller, __vault__, type(uint).max);
         prop_RT_mint_withdraw(caller, shares);
     }
@@ -273,6 +288,7 @@ abstract contract ERC4626Test is ERC4626Prop {
     function test_RT_mint_redeem(Init memory init, uint shares) public virtual {
         setupVault(init);
         address caller = init.user[0];
+        shares = bound(shares, 0, _max_mint(caller));
         _approve(__underlying__, caller, __vault__, type(uint).max);
         prop_RT_mint_redeem(caller, shares);
     }
@@ -280,6 +296,7 @@ abstract contract ERC4626Test is ERC4626Prop {
     function test_RT_withdraw_mint(Init memory init, uint assets) public virtual {
         setupVault(init);
         address caller = init.user[0];
+        assets = bound(assets, 0, _max_withdraw(caller));
         _approve(__underlying__, caller, __vault__, type(uint).max);
         prop_RT_withdraw_mint(caller, assets);
     }
@@ -287,6 +304,7 @@ abstract contract ERC4626Test is ERC4626Prop {
     function test_RT_withdraw_deposit(Init memory init, uint assets) public virtual {
         setupVault(init);
         address caller = init.user[0];
+        assets = bound(assets, 0, _max_withdraw(caller));
         _approve(__underlying__, caller, __vault__, type(uint).max);
         prop_RT_withdraw_deposit(caller, assets);
     }
@@ -307,5 +325,21 @@ abstract contract ERC4626Test is ERC4626Prop {
         (bool success, bytes memory retdata) = token.call(abi.encodeWithSelector(IERC20.approve.selector, spender, amount));
         vm.assume(success);
         if (retdata.length > 0) vm.assume(abi.decode(retdata, (bool)));
+    }
+
+    function _max_deposit(address from) internal virtual returns (uint) {
+        return IERC20(__underlying__).balanceOf(from);
+    }
+
+    function _max_mint(address from) internal virtual returns (uint) {
+        return vault_convertToShares(IERC20(__underlying__).balanceOf(from));
+    }
+
+    function _max_withdraw(address from) internal virtual returns (uint) {
+        return vault_convertToAssets(IERC20(__vault__).balanceOf(from)); // may be different from maxWithdraw(from)
+    }
+
+    function _max_redeem(address from) internal virtual returns (uint) {
+        return IERC20(__vault__).balanceOf(from); // may be different from maxRedeem(from)
     }
 }

--- a/ERC4626.test.sol
+++ b/ERC4626.test.sol
@@ -27,34 +27,34 @@ abstract contract ERC4626Test is ERC4626Prop {
     //
     // init.user[i]'s assets == init.asset[i]
     // init.user[i]'s shares == init.share[i]
-    function setupVault(Init memory init) public virtual {
+    function setUpVault(Init memory init) public virtual {
         // setup initial shares and assets for individual users
         for (uint i = 0; i < N; i++) {
             address user = init.user[i];
             vm.assume(_isEOA(user));
             // shares
             uint shares = init.share[i];
-            try IMockERC20(__underlying__).mint(user, shares) {} catch { vm.assume(false); }
-            _approve(__underlying__, user, __vault__, shares);
-            vm.prank(user); try IERC4626(__vault__).deposit(shares, user) {} catch { vm.assume(false); }
+            try IMockERC20(_underlying_).mint(user, shares) {} catch { vm.assume(false); }
+            _approve(_underlying_, user, _vault_, shares);
+            vm.prank(user); try IERC4626(_vault_).deposit(shares, user) {} catch { vm.assume(false); }
             // assets
             uint assets = init.asset[i];
-            try IMockERC20(__underlying__).mint(user, assets) {} catch { vm.assume(false); }
+            try IMockERC20(_underlying_).mint(user, assets) {} catch { vm.assume(false); }
         }
 
         // setup initial yield for vault
-        setupYield(init);
+        setUpYield(init);
     }
 
     // setup initial yield
-    function setupYield(Init memory init) public virtual {
+    function setUpYield(Init memory init) public virtual {
         if (init.yield >= 0) { // gain
             uint gain = uint(init.yield);
-            try IMockERC20(__underlying__).mint(__vault__, gain) {} catch { vm.assume(false); } // this can be replaced by calling yield generating functions if provided by the vault
+            try IMockERC20(_underlying_).mint(_vault_, gain) {} catch { vm.assume(false); } // this can be replaced by calling yield generating functions if provided by the vault
         } else { // loss
             vm.assume(init.yield > type(int).min); // avoid overflow in conversion
             uint loss = uint(-1 * init.yield);
-            try IMockERC20(__underlying__).burn(__vault__, loss) {} catch { vm.assume(false); } // this can be replaced by calling yield generating functions if provided by the vault
+            try IMockERC20(_underlying_).burn(_vault_, loss) {} catch { vm.assume(false); } // this can be replaced by calling yield generating functions if provided by the vault
         }
     }
 
@@ -63,13 +63,13 @@ abstract contract ERC4626Test is ERC4626Prop {
     //
 
     function test_asset(Init memory init) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller = init.user[0];
         prop_asset(caller);
     }
 
     function test_totalAssets(Init memory init) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller = init.user[0];
         prop_totalAssets(caller);
     }
@@ -79,14 +79,14 @@ abstract contract ERC4626Test is ERC4626Prop {
     //
 
     function test_convertToShares(Init memory init, uint assets) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller1 = init.user[0];
         address caller2 = init.user[1];
         prop_convertToShares(caller1, caller2, assets);
     }
 
     function test_convertToAssets(Init memory init, uint shares) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller1 = init.user[0];
         address caller2 = init.user[1];
         prop_convertToAssets(caller1, caller2, shares);
@@ -97,28 +97,28 @@ abstract contract ERC4626Test is ERC4626Prop {
     //
 
     function test_maxDeposit(Init memory init) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
         prop_maxDeposit(caller, receiver);
     }
 
     function test_previewDeposit(Init memory init, uint assets) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
         address other    = init.user[2];
         assets = bound(assets, 0, _max_deposit(caller));
-        _approve(__underlying__, caller, __vault__, type(uint).max);
+        _approve(_underlying_, caller, _vault_, type(uint).max);
         prop_previewDeposit(caller, receiver, other, assets);
     }
 
     function test_deposit(Init memory init, uint assets, uint allowance) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
         assets = bound(assets, 0, _max_deposit(caller));
-        _approve(__underlying__, caller, __vault__, allowance);
+        _approve(_underlying_, caller, _vault_, allowance);
         prop_deposit(caller, receiver, assets);
     }
 
@@ -127,28 +127,28 @@ abstract contract ERC4626Test is ERC4626Prop {
     //
 
     function test_maxMint(Init memory init) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
         prop_maxMint(caller, receiver);
     }
 
     function test_previewMint(Init memory init, uint shares) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
         address other    = init.user[2];
         shares = bound(shares, 0, _max_mint(caller));
-        _approve(__underlying__, caller, __vault__, type(uint).max);
+        _approve(_underlying_, caller, _vault_, type(uint).max);
         prop_previewMint(caller, receiver, other, shares);
     }
 
     function test_mint(Init memory init, uint shares, uint allowance) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
         shares = bound(shares, 0, _max_mint(caller));
-        _approve(__underlying__, caller, __vault__, allowance);
+        _approve(_underlying_, caller, _vault_, allowance);
         prop_mint(caller, receiver, shares);
     }
 
@@ -157,43 +157,43 @@ abstract contract ERC4626Test is ERC4626Prop {
     //
 
     function test_maxWithdraw(Init memory init) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller = init.user[0];
         address owner  = init.user[1];
         prop_maxWithdraw(caller, owner);
     }
 
     function test_previewWithdraw(Init memory init, uint assets) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
         address owner    = init.user[2];
         address other    = init.user[3];
         assets = bound(assets, 0, _max_withdraw(owner));
-        _approve(__vault__, owner, caller, type(uint).max);
+        _approve(_vault_, owner, caller, type(uint).max);
         prop_previewWithdraw(caller, receiver, owner, other, assets);
     }
 
     function test_withdraw(Init memory init, uint assets, uint allowance) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
         address owner    = init.user[2];
         assets = bound(assets, 0, _max_withdraw(owner));
-        _approve(__vault__, owner, caller, allowance);
+        _approve(_vault_, owner, caller, allowance);
         prop_withdraw(caller, receiver, owner, assets);
     }
 
     function testFail_withdraw(Init memory init, uint assets) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
         address owner    = init.user[2];
         assets = bound(assets, 0, _max_withdraw(owner));
         vm.assume(caller != owner);
         vm.assume(assets > 0);
-        _approve(__vault__, owner, caller, 0);
-        vm.prank(caller); uint shares = IERC4626(__vault__).withdraw(assets, receiver, owner);
+        _approve(_vault_, owner, caller, 0);
+        vm.prank(caller); uint shares = IERC4626(_vault_).withdraw(assets, receiver, owner);
         assertGt(shares, 0); // this assert is expected to fail
     }
 
@@ -202,43 +202,43 @@ abstract contract ERC4626Test is ERC4626Prop {
     //
 
     function test_maxRedeem(Init memory init) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller = init.user[0];
         address owner  = init.user[1];
         prop_maxRedeem(caller, owner);
     }
 
     function test_previewRedeem(Init memory init, uint shares) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
         address owner    = init.user[2];
         address other    = init.user[3];
         shares = bound(shares, 0, _max_redeem(owner));
-        _approve(__vault__, owner, caller, type(uint).max);
+        _approve(_vault_, owner, caller, type(uint).max);
         prop_previewRedeem(caller, receiver, owner, other, shares);
     }
 
     function test_redeem(Init memory init, uint shares, uint allowance) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
         address owner    = init.user[2];
         shares = bound(shares, 0, _max_redeem(owner));
-        _approve(__vault__, owner, caller, allowance);
+        _approve(_vault_, owner, caller, allowance);
         prop_redeem(caller, receiver, owner, shares);
     }
 
     function testFail_redeem(Init memory init, uint shares) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller   = init.user[0];
         address receiver = init.user[1];
         address owner    = init.user[2];
         shares = bound(shares, 0, _max_redeem(owner));
         vm.assume(caller != owner);
         vm.assume(shares > 0);
-        _approve(__vault__, owner, caller, 0);
-        vm.prank(caller); IERC4626(__vault__).redeem(shares, receiver, owner);
+        _approve(_vault_, owner, caller, 0);
+        vm.prank(caller); IERC4626(_vault_).redeem(shares, receiver, owner);
     }
 
     //
@@ -246,66 +246,66 @@ abstract contract ERC4626Test is ERC4626Prop {
     //
 
     function test_RT_deposit_redeem(Init memory init, uint assets) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller = init.user[0];
         assets = bound(assets, 0, _max_deposit(caller));
-        _approve(__underlying__, caller, __vault__, type(uint).max);
+        _approve(_underlying_, caller, _vault_, type(uint).max);
         prop_RT_deposit_redeem(caller, assets);
     }
 
     function test_RT_deposit_withdraw(Init memory init, uint assets) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller = init.user[0];
         assets = bound(assets, 0, _max_deposit(caller));
-        _approve(__underlying__, caller, __vault__, type(uint).max);
+        _approve(_underlying_, caller, _vault_, type(uint).max);
         prop_RT_deposit_withdraw(caller, assets);
     }
 
     function test_RT_redeem_deposit(Init memory init, uint shares) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller = init.user[0];
         shares = bound(shares, 0, _max_redeem(caller));
-        _approve(__underlying__, caller, __vault__, type(uint).max);
+        _approve(_underlying_, caller, _vault_, type(uint).max);
         prop_RT_redeem_deposit(caller, shares);
     }
 
     function test_RT_redeem_mint(Init memory init, uint shares) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller = init.user[0];
         shares = bound(shares, 0, _max_redeem(caller));
-        _approve(__underlying__, caller, __vault__, type(uint).max);
+        _approve(_underlying_, caller, _vault_, type(uint).max);
         prop_RT_redeem_mint(caller, shares);
     }
 
     function test_RT_mint_withdraw(Init memory init, uint shares) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller = init.user[0];
         shares = bound(shares, 0, _max_mint(caller));
-        _approve(__underlying__, caller, __vault__, type(uint).max);
+        _approve(_underlying_, caller, _vault_, type(uint).max);
         prop_RT_mint_withdraw(caller, shares);
     }
 
     function test_RT_mint_redeem(Init memory init, uint shares) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller = init.user[0];
         shares = bound(shares, 0, _max_mint(caller));
-        _approve(__underlying__, caller, __vault__, type(uint).max);
+        _approve(_underlying_, caller, _vault_, type(uint).max);
         prop_RT_mint_redeem(caller, shares);
     }
 
     function test_RT_withdraw_mint(Init memory init, uint assets) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller = init.user[0];
         assets = bound(assets, 0, _max_withdraw(caller));
-        _approve(__underlying__, caller, __vault__, type(uint).max);
+        _approve(_underlying_, caller, _vault_, type(uint).max);
         prop_RT_withdraw_mint(caller, assets);
     }
 
     function test_RT_withdraw_deposit(Init memory init, uint assets) public virtual {
-        setupVault(init);
+        setUpVault(init);
         address caller = init.user[0];
         assets = bound(assets, 0, _max_withdraw(caller));
-        _approve(__underlying__, caller, __vault__, type(uint).max);
+        _approve(_underlying_, caller, _vault_, type(uint).max);
         prop_RT_withdraw_deposit(caller, assets);
     }
 
@@ -328,22 +328,22 @@ abstract contract ERC4626Test is ERC4626Prop {
     }
 
     function _max_deposit(address from) internal virtual returns (uint) {
-        if (__unlimited_amount__) return type(uint).max;
-        return IERC20(__underlying__).balanceOf(from);
+        if (_unlimitedAmount) return type(uint).max;
+        return IERC20(_underlying_).balanceOf(from);
     }
 
     function _max_mint(address from) internal virtual returns (uint) {
-        if (__unlimited_amount__) return type(uint).max;
-        return vault_convertToShares(IERC20(__underlying__).balanceOf(from));
+        if (_unlimitedAmount) return type(uint).max;
+        return vault_convertToShares(IERC20(_underlying_).balanceOf(from));
     }
 
     function _max_withdraw(address from) internal virtual returns (uint) {
-        if (__unlimited_amount__) return type(uint).max;
-        return vault_convertToAssets(IERC20(__vault__).balanceOf(from)); // may be different from maxWithdraw(from)
+        if (_unlimitedAmount) return type(uint).max;
+        return vault_convertToAssets(IERC20(_vault_).balanceOf(from)); // may be different from maxWithdraw(from)
     }
 
     function _max_redeem(address from) internal virtual returns (uint) {
-        if (__unlimited_amount__) return type(uint).max;
-        return IERC20(__vault__).balanceOf(from); // may be different from maxRedeem(from)
+        if (_unlimitedAmount) return type(uint).max;
+        return IERC20(_vault_).balanceOf(from); // may be different from maxRedeem(from)
     }
 }

--- a/README.md
+++ b/README.md
@@ -69,20 +69,22 @@ import { ERC20Mock   } from "/path/to/mocks/ERC20Mock.sol";
 import { ERC4626Mock } from "/path/to/mocks/ERC4626Mock.sol";
 
 contract ERC4626StdTest is ERC4626Test {
-
     function setUp() public override {
-        __underlying__ = address(new ERC20Mock("Mock ERC20", "MERC20", 18));
-        __vault__ = address(new ERC4626Mock(ERC20Mock(__underlying__), "Mock ERC4626", "MERC4626"));
-        __delta__ = 0;
+        _underlying_ = address(new ERC20Mock("Mock ERC20", "MERC20", 18));
+        _vault_ = address(new ERC4626Mock(ERC20Mock(__underlying__), "Mock ERC4626", "MERC4626"));
+        _delta_ = 0;
+        _vaultMayBeEmpty = false;
+        _unlimitedAmount = false;
     }
-
 }
 ```
 
 Specifically, set the state variables as follows:
-- `__vault__`: the address of your ERC4626 vault.
-- `__underlying__`: the address of the underlying asset of your vault. Note that the default `setupVault()` and `setupYield()` methods of `ERC4626Test` assume that it implements `mint(address to, uint value)` and `burn(address from, uint value)`. You can override the setup methods with your own if such `mint()` and `burn()` are not implemented.
-- `__delta__`: the maximum approximation error size to be passed to [`assertApproxEqAbs()`]. It must be given as an absolute value (not a percentage) in the smallest unit (e.g., Wei or Satoshi). Note that all the tests are expected to pass with `__delta__ == 0` as long as your vault follows the [preferred rounding direction] as specified in the standard. If your vault doesn't follow the preferred rounding direction, you can set `__delta__` to a reasonable size of rounding errors where the adversarial profit of exploiting such rounding errors stays sufficiently small compared to the gas cost. (You can read our [post] for more about the adversarial profit.) 
+- `_vault_`: the address of your ERC4626 vault.
+- `_underlying_`: the address of the underlying asset of your vault. Note that the default `setupVault()` and `setupYield()` methods of `ERC4626Test` assume that it implements `mint(address to, uint value)` and `burn(address from, uint value)`. You can override the setup methods with your own if such `mint()` and `burn()` are not implemented.
+- `_delta_`: the maximum approximation error size to be passed to [`assertApproxEqAbs()`]. It must be given as an absolute value (not a percentage) in the smallest unit (e.g., Wei or Satoshi). Note that all the tests are expected to pass with `__delta__ == 0` as long as your vault follows the [preferred rounding direction] as specified in the standard. If your vault doesn't follow the preferred rounding direction, you can set `__delta__` to a reasonable size of rounding errors where the adversarial profit of exploiting such rounding errors stays sufficiently small compared to the gas cost. (You can read our [post] for more about the adversarial profit.)
+- `_vaultMayBeEmpty`: when set to false, fuzz inputs that empties the vault are ignored.
+- `_unlimitedAmount`: when set to false, fuzz inputs are restricted to the currently available amount from the caller. Limiting the amount can speed up fuzzing, but may miss some edge cases.
 
 [`assertApproxEqAbs()`]: <https://book.getfoundry.sh/reference/forge-std/assertApproxEqAbs>
 


### PR DESCRIPTION
New options flags:
- `__vault_may_be_empty__`: when set to false, do _not_ consider the case the vault being emptied.
- `__unlimited_amount__`: when set to false, restrict fuzz inputs to the currently available amount from the caller.