### PR TITLE
avoid expectRevert

### DIFF
--- a/ERC4626.test.sol
+++ b/ERC4626.test.sol
@@ -194,8 +194,10 @@ abstract contract ERC4626Test is ERC4626Prop {
         vm.assume(assets > 0);
         _approve(_vault_, owner, caller, 0);
         vm.prank(caller);
-        vm.expectRevert(); // We do not provide a specific revert reason, as it may vary depending on the implementation.
-        IERC4626(_vault_).withdraw(assets, receiver, owner);
+        (bool success,) = _vault_.call(
+            abi.encodeWithSelector(IERC4626.withdraw.selector, assets, receiver, owner)
+        );
+        assertFalse(success);
     }
 
     //
@@ -240,8 +242,10 @@ abstract contract ERC4626Test is ERC4626Prop {
         vm.assume(shares > 0);
         _approve(_vault_, owner, caller, 0);
         vm.prank(caller);
-        vm.expectRevert(); // We do not provide a specific revert reason, as it may vary depending on the implementation.
-        IERC4626(_vault_).redeem(shares, receiver, owner);
+        (bool success,) = _vault_.call(
+            abi.encodeWithSelector(IERC4626.redeem.selector, shares, receiver, owner)
+        );
+        assertFalse(success);
     }
 
     //


### PR DESCRIPTION
uses low-level calls instead of expectRevert cheatcode, to minimize the impact of potential future changes in cheatcode behaviors